### PR TITLE
Replaced golang Sarama kafka interface with Confluent.

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2021-12-20
+
+### Changed
+
+- SMD now uses the latest hms-msgbus with Confluent kafka.
+
 ## [2.0.0] - 2021-11-19
 
 ### Changed

--- a/charts/v2.0/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v2.0/cray-hms-hmnfd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmnfd"
-version: 2.0.0
+version: 2.0.1
 description: "Kubernetes resources for cray-hms-hmnfd"
 home: "https://github.com/Cray-HPE/hms-hmnfd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.12.0"
+appVersion: "1.13.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-hmnfd/values.yaml
+++ b/charts/v2.0/cray-hms-hmnfd/values.yaml
@@ -8,7 +8,7 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.12.0
+  appVersion: 1.13.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -10,6 +10,7 @@ chartVersionToCSMVersion:
 chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "1.12.0"
+  "2.0.1": "1.13.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Replaced golang Sarama kafka interface with Confluent.
Sarama interface can be buggy and can miss messages, etc.
Confluent is more stable and mature.

No API changes were made; this change is 100% backward compatible.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: © Copyright 2014-2020 Hewlett Packard Enterprise Development LP    ? Y

### Issues and Related PRs

* Resolves CASMHMS-5300

### Testing

Tested on:

* baldar

Was a fresh Install tested? N   No need for this.
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
Was a CT test run?          Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

Upgraded to new version of HMNFD which contained the new hms-msgbus
library.  Verified that it was able to connect and send messages on
the Kafka bus using the kafka pod utilities.

### Risks and Mitigations

Should be low risk, since the Confluent golang package is mature
and stable.

