### PR TITLE
CASMHMS-5427 Build HMNFD with GitHub Actions and convert to Helm CT tests

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,10 +5,11 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0] - 2022-03-14
+## [2.1.0] - 2022-05-12
 
 ### Changed
 
 - Updated HMNFD to build using GitHub Actions instead of Jenkins.
 - Pull images from artifactory.algol60.net instead of arti.dev.cray.com.
 - Added a runCT.sh script that can run the CT tests in a docker-compose environment.
+- Refactored runIntegration.sh and the disruptive Tavern integration tests.

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -1,0 +1,14 @@
+# Changelog for v2.1
+
+All notable changes to this project for v2.1.X will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.0] - 2022-03-14
+
+### Changed
+
+- Updated HMNFD to build using GitHub Actions instead of Jenkins.
+- Pull images from artifactory.algol60.net instead of arti.dev.cray.com.
+- Added a runCT.sh script that can run the CT tests in a docker-compose environment.

--- a/charts/v2.1/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.14.0"
+appVersion: "1.15.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: "cray-hms-hmnfd"
+version: 2.1.0
+description: "Kubernetes resources for cray-hms-hmnfd"
+home: "https://github.com/Cray-HPE/hms-hmnfd-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-hmi-nfd"
+dependencies:
+  - name: cray-service
+    version: "~7.0.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "1.14.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-hmnfd/templates/tests/test-smoke.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/templates/tests/test-smoke.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      labels:
+        app.kubernetes.io/managed-by: "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance: "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: [ "until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; entrypoint.sh smoke -f smoke.json -u http://cray-hmnfd"]

--- a/charts/v2.1/cray-hms-hmnfd/templates/tests/test-smoke.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/templates/tests/test-smoke.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    "helm.sh/hook-weight": "-1" #run this first!
+    "helm.sh/hook-weight": "-1"
 
   labels:
     app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"

--- a/charts/v2.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.14.0
-  testVersion: 1.14.0
+  appVersion: 1.15.0
+  testVersion: 1.15.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd

--- a/charts/v2.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/values.yaml
@@ -1,0 +1,93 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+
+global:
+  appVersion: 1.14.0
+  testVersion: 1.14.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd-test
+    pullPolicy: IfNotPresent
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-hmnfd"
+  fullnameOverride: "cray-hmnfd"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-hmnfd
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  etcdCluster:
+    enabled: true
+    resources:
+      limits:
+        cpu: "2"
+        memory: 4Gi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+  containers:
+    cray-hmnfd:
+      name: "cray-hmnfd"
+      image:
+        repository: "artifactory.algol60.net/csm-docker/stable/cray-hmnfd"
+      ports:
+        - name: http
+          containerPort: 28600
+      env:
+        - name: SM_URL
+          value: "http://cray-smd/hsm/v2"
+        - name: INBOUND_SCN_URL
+          value: "http://cray-hmnfd/hmi/v1/scn"
+        # Remove this to have hmnfd use ETCD.  The etcd operator will
+        # provide the hmnfd container with ETCD_HOST and ETCD_PORT to
+        # allow it to determine the KV URL.
+        # - name: KV_URL
+        #   value: "mem:"
+      livenessProbe:
+        httpGet:
+          port: 28600
+          path: /hmi/v1/liveness
+        initialDelaySeconds: 10
+        periodSeconds: 30
+      readinessProbe:
+        httpGet:
+          port: 28600
+          path: /hmi/v1/readiness
+        initialDelaySeconds: 5
+        periodSeconds: 30
+      resources:
+        limits:
+          cpu: "4"
+          memory: 2Gi
+        requests:
+          cpu: 64m
+          memory: 512Mi
+  podAnnotations:
+    traffic.sidecar.istio.io/excludeOutboundPorts: 8082,9092,2181,2379,2380
+  ingress:
+    enabled: true
+    uri: " "
+    prefix: /apis/hmnfd

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -3,6 +3,7 @@
 chartVersionToCSMVersion:
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  ">=2.1.0": "~1.3.0"
 
 # The application version must be compliant to semantic versioning. 
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -12,6 +13,7 @@ chartVersionToApplicationVersion:
   "2.0.0": "1.12.0"
   "2.0.1": "1.13.0"
   "2.0.2": "1.13.0"
+  "2.1.0": "1.14.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -13,7 +13,7 @@ chartVersionToApplicationVersion:
   "2.0.0": "1.12.0"
   "2.0.1": "1.13.0"
   "2.0.2": "1.13.0"
-  "2.1.0": "1.14.0"
+  "2.1.0": "1.15.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

* Update HMNFD to build using GitHub Actions instead of Jenkins
* Pull images from algol60 instead of arti.dev.cray.com
* Use HSM /v2 rather than /v1 which will soon be removed
* Update Alpine base image version
* Stop building CT test RPMs and instead package/execute them via Helm
* Add a runCT.sh script/workflow that stands up an instance of HMNFD and executes the CT tests against it

### Issues and Related PRs

* Resolves CASMHMS-5427.
* Resolves CASMHMS-5415.

### Testing

This change was tested by executing the existing HMNFD unit and integration tests and verifying that they continued to pass. The HMNFD CT tests were also run as part of the new GitHub Actions workflow and verified to pass. The new version of HMNFD was also installed on Mug using Helm and confirmed to succeed by executing the new CT test Helm job, as well as the former RPM version of the CT tests, and verified to pass. Logs were inspected as well and were found to only contain failures/errors attributable to an unhealthy system environment and not caused by these changes.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? Y

### Risks and Mitigations

Moderate risk since this is a significant refactoring of how HMNFD builds and is tested, but the core functionality is unchanged.