### PR TITLE
CASMHMS-5575 Helm CT Test job configuration updates for no retries and istio sidecar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Cray / HPE
+Copyright (c) 2021-2022 Cray / HPE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2022-06-07
+
+### Added
+
+- Set CT test job backoffLimit to zero so retries aren't attempted on failures.
+- Set holdApplicationUntilProxyStarts pod annotation for istio sidecar.
+
 ## [2.1.0] - 2022-05-12
 
 ### Changed

--- a/charts/v2.1/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmnfd"
-version: 2.1.0
+version: 2.1.1
 description: "Kubernetes resources for cray-hms-hmnfd"
 home: "https://github.com/Cray-HPE/hms-hmnfd-charts"
 sources:

--- a/charts/v2.1/cray-hms-hmnfd/templates/tests/test-smoke.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/templates/tests/test-smoke.yaml
@@ -12,9 +12,12 @@ metadata:
     app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
 
 spec:
+  backoffLimit: 0
   template:
     metadata:
       name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
       labels:
         app.kubernetes.io/managed-by: "{{ include "cray-service.name" . }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}-test-smoke"
@@ -30,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; entrypoint.sh smoke -f smoke.json -u http://cray-hmnfd"]
+          args: [ "entrypoint.sh smoke -f smoke.json -u http://cray-hmnfd"]

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -15,6 +15,7 @@ chartVersionToApplicationVersion:
   "2.0.2": "1.13.0"
   "2.0.3": "1.14.0"
   "2.1.0": "1.15.0"
+  "2.1.1": "1.15.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Set CT test job backoffLimit to zero so retries aren't attempted on failures
- Set holdApplicationUntilProxyStarts pod annotation for istio sidecar to cleanup the "Waiting for Sidecar" code

### Issues and Related PRs

* Partially resolves CASMHMS-5575.

### Testing

See testing from: https://github.com/Cray-HPE/hms-bss-charts/pull/15

### Risks and Mitigations

Low risk, minor changes to new Helm CT test job configuration