### PR TITLE
CASMHMS-5458 Coordination for HMS CT Helm tests

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2022-06-22
+
+### Changed
+
+- Updated CT tests to hms-test:3.1.0 image as part of Helm test coordination.
+
 ## [2.1.1] - 2022-06-07
 
 ### Added

--- a/charts/v2.1/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmnfd"
-version: 2.1.1
+version: 2.1.2
 description: "Kubernetes resources for cray-hms-hmnfd"
 home: "https://github.com/Cray-HPE/hms-hmnfd-charts"
 sources:

--- a/charts/v2.1/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/Chart.yaml
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.15.0"
+appVersion: "1.16.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/values.yaml
@@ -8,10 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  #appVersion: 1.15.0
-  appVersion: 1.15.0-20220616171832.6fe8b20
-  #testVersion: 1.15.0
-  testVersion: 1.15.0-20220616171838.6fe8b20
+  appVersion: 1.16.0
+  testVersion: 1.16.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd
@@ -20,7 +18,7 @@ image:
 tests:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd-test
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
 
 cray-service:
   type: "Deployment"

--- a/charts/v2.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/values.yaml
@@ -8,8 +8,10 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.15.0
-  testVersion: 1.15.0
+  #appVersion: 1.15.0
+  appVersion: 1.15.0-20220616171832.6fe8b20
+  #testVersion: 1.15.0
+  testVersion: 1.15.0-20220616171838.6fe8b20
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd
@@ -18,7 +20,7 @@ image:
 tests:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd-test
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 
 cray-service:
   type: "Deployment"

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -16,6 +16,7 @@ chartVersionToApplicationVersion:
   "2.0.3": "1.14.0"
   "2.1.0": "1.15.0"
   "2.1.1": "1.15.0"
+  "2.1.2": "1.16.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Update CT tests to stable hms-test:3.1.0 image (upgrades pytest and tavern to work around python issue43798)
- Pull Alpine base image from correct location in algol60 artifactory
- CT test cleanup

### Issues and Related PRs

* Partially resolves CASMHMS-5458.

### Testing

This change was tested by deploying the updated version of the service and chart onto Mug, executing the Helm CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, test update.