### PR TITLE
Change HSM v1 references in hmnfd to v2

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2022-06-29
+
+### Changed
+
+- HSM v1 references to v2
+
 ## [2.1.2] - 2022-06-22
 
 ### Changed

--- a/charts/v2.1/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmnfd"
-version: 2.1.2
+version: 2.1.3
 description: "Kubernetes resources for cray-hms-hmnfd"
 home: "https://github.com/Cray-HPE/hms-hmnfd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.16.0"
+appVersion: "1.17.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.16.0
-  testVersion: 1.16.0
+  appVersion: 1.17.0
+  testVersion: 1.17.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -17,6 +17,7 @@ chartVersionToApplicationVersion:
   "2.1.0": "1.15.0"
   "2.1.1": "1.15.0"
   "2.1.2": "1.16.0"
+  "2.1.3": "1.17.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Update hmnfd image version for the removal of HSM v1 references

## Issues and Related PRs

* Resolves [CASMHMS-5545](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5545)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable