### PR TITLE
CASMHMS-5612 Helm CT test enhancements and CVE remediation

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,11 +5,17 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2022-07-20
+
+### Changed
+
+- Updated CT tests to hms-test:3.2.0 image to pick up Helm test enhancements and CVE fixes.
+
 ## [2.1.3] - 2022-06-29
 
 ### Changed
 
-- HSM v1 references to v2
+- HSM v1 references to v2.
 
 ## [2.1.2] - 2022-06-22
 

--- a/charts/v2.1/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmnfd"
-version: 2.1.3
+version: 2.1.4
 description: "Kubernetes resources for cray-hms-hmnfd"
 home: "https://github.com/Cray-HPE/hms-hmnfd-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.17.0"
+appVersion: "1.18.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v2.1/cray-hms-hmnfd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.17.0
-  testVersion: 1.17.0
+  appVersion: 1.18.0
+  testVersion: 1.18.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -18,6 +18,7 @@ chartVersionToApplicationVersion:
   "2.1.1": "1.15.0"
   "2.1.2": "1.16.0"
   "2.1.3": "1.17.0"
+  "2.1.4": "1.18.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes for the Helm CT tests:

- kill the istio sidecar after the tests run to save wait time
- remove build dependencies from final test image that aren't needed to run the tests
- revert the test base image to alpine:3.15 to resolve CVEs

### Issues and Related PRs

* Partially resolves CASMHMS-5612.

### Testing

This change was tested by deploying a new version of an HMS service on Mug which pulled in the latest version of the hms-test image, executing its Helm CT tests, and verifying that they passed. Also verified that the test pod was no longer stuck in "NotReady" after the tests completed. Lastly, verified the change in the runCT environment and confirmed that it passed its Snyk checks that were previously failing.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, minor test changes and CVE remediation.