### PR TITLE
Added support for VirtualNode types

### DIFF
--- a/changelog/v4.0.md
+++ b/changelog/v4.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v4.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2023-09-19
+
+### Added
+
+- Added support for VirtualNode types
+
 ## [4.0.0] - 2023-06-30
 
 ### Added

--- a/charts/v4.0/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v4.0/cray-hms-hmnfd/Chart.yaml
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.20.0"
+appVersion: "1.21.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v4.0/cray-hms-hmnfd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmnfd"
-version: 4.0.0
+version: 4.0.1
 description: "Kubernetes resources for cray-hms-hmnfd"
 home: "https://github.com/Cray-HPE/hms-hmnfd-charts"
 sources:
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.19.0"
+appVersion: "1.20.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v4.0/cray-hms-hmnfd/values.yaml
+++ b/charts/v4.0/cray-hms-hmnfd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.19.0
-  testVersion: 1.19.0
+  appVersion: 1.20.0
+  testVersion: 1.20.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd

--- a/charts/v4.0/cray-hms-hmnfd/values.yaml
+++ b/charts/v4.0/cray-hms-hmnfd/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.20.0
-  testVersion: 1.20.0
+  appVersion: 1.21.0
+  testVersion: 1.21.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -24,6 +24,7 @@ chartVersionToApplicationVersion:
   "3.0.1": "1.18.1"
   "3.0.2": "1.18.1"
   "4.0.0": "1.19.0"
+  "4.0.1": "1.20.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -24,7 +24,7 @@ chartVersionToApplicationVersion:
   "3.0.1": "1.18.1"
   "3.0.2": "1.18.1"
   "4.0.0": "1.19.0"
-  "4.0.1": "1.20.0"
+  "4.0.1": "1.21.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
Changed to use app version 1.20.0

CASMHMS-6075

## Summary and Scope

Changed to use app version 1.20.0 which supports the VirtualNode type

### Issues and Related PRs

* Resolves CASMHMS-6075

### Testing

Tested on:

* docker compose env
* mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y
Was a Downgrade tested?                Y/N   If not, Why? Y


### Risks and Mitigations

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable