### PR TITLE
CASMHMS-6417: Updated image and module dependencies for security updates

### DIFF
--- a/changelog/v4.1.md
+++ b/changelog/v4.1.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added image-pprof Makefile support
 - Resolved build warnings in Dockerfiles and docker compose files
 - Updated tests to look for 404 codes instead of 405 code due to gorilla/mux update
+- Internal tracking ticket: CASMHMS-6417

--- a/changelog/v4.1.md
+++ b/changelog/v4.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v4.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.1.0] - 2025-03-18
+## [4.1.0] - 2025-03-25
 
 ### Security
 

--- a/changelog/v4.1.md
+++ b/changelog/v4.1.md
@@ -11,3 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated image and module dependencies for security updates
 - Various code changes to accomodate module updates
+- Added image-pprof Makefile support
+- Resolved build warnings in Dockerfiles and docker compose files
+- Updated tests to look for 404 codes instead of 405 code due to gorilla/mux update

--- a/changelog/v4.1.md
+++ b/changelog/v4.1.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated image and module dependencies for security updates
 - Various code changes to accomodate module updates
+- Update version of Go to v1.24
 - Added image-pprof Makefile support
 - Resolved build warnings in Dockerfiles and docker compose files
 - Updated tests to look for 404 codes instead of 405 code due to gorilla/mux update

--- a/changelog/v4.1.md
+++ b/changelog/v4.1.md
@@ -1,0 +1,13 @@
+# Changelog for v4.1
+
+All notable changes to this project for v4.1.X will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.1.0] - 2025-03-18
+
+### Security
+
+- Updated image and module dependencies for security updates
+- Various code changes to accomodate module updates

--- a/charts/v4.1/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v4.1/cray-hms-hmnfd/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: "cray-hms-hmnfd"
+version: 4.1.0
+description: "Kubernetes resources for cray-hms-hmnfd"
+home: "https://github.com/Cray-HPE/hms-hmnfd-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-hmnfd"
+dependencies:
+  - name: cray-service
+    version: "~11.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  - name: cray-etcd-base
+    version: "~1.2"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "1.24.0"  # update pprof image version below as well
+annotations:
+  artifacthub.io/images: |-
+    - name: cray-hmnfd-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-hmnfd-pprof:1.24.0
+  artifacthub.io/license: "MIT"

--- a/charts/v4.1/cray-hms-hmnfd/templates/tests/test-functional.yaml
+++ b/charts/v4.1/cray-hms-hmnfd/templates/tests/test-functional.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/app/tavern_global_config_ct_production.yaml -p /src/app/api/1-non-disruptive"]

--- a/charts/v4.1/cray-hms-hmnfd/templates/tests/test-smoke.yaml
+++ b/charts/v4.1/cray-hms-hmnfd/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by: "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance: "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: [ "entrypoint.sh smoke -f smoke.json -u http://cray-hmnfd"]

--- a/charts/v4.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v4.1/cray-hms-hmnfd/values.yaml
@@ -1,0 +1,126 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+
+global:
+  appVersion: 1.24.0
+  testVersion: 1.24.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-hmnfd-hmth-test
+    pullPolicy: IfNotPresent
+
+cray-etcd-base:
+  nameOverride: "cray-hmnfd"
+  fullnameOverride: "cray-hmnfd"
+  etcd:
+    enabled: true
+    fullnameOverride: "cray-hmnfd-bitnami-etcd"
+    nameOverride: "cray-hmnfd-bitnami-tcd"
+    disasterRecovery:
+      cronjob:
+        snapshotsDir: "/snapshots/cray-hmnfd-bitnami-etcd"
+        schedule: "0 */1 * * *"
+        historyLimit: 1
+        snapshotHistoryLimit: 24
+    extraEnvVars:
+      - name: ETCD_HEARTBEAT_INTERVAL
+        value: "4200"
+      - name: ETCD_ELECTION_TIMEOUT
+        value: "21000"
+      - name: ETCD_MAX_SNAPSHOTS
+        value: "5"
+      - name: ETCD_QUOTA_BACKEND_BYTES
+        value: "10737418240"
+      - name: ETCD_SNAPSHOT_COUNT
+        value: "10000"
+      - name: ETCD_SNAPSHOT_HISTORY_LIMIT
+        value: "24"
+      - name: ETCD_DISABLE_PRESTOP
+        value: "yes"
+    extraVolumes:
+    - configMap:
+        defaultMode: 420
+        name: cray-hmnfd-bitnami-etcd-config
+      name: etcd-config
+    resources:
+      limits:
+        cpu: "2"
+        memory: 4Gi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-hmnfd"
+  fullnameOverride: "cray-hmnfd"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-hmnfd
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  etcdWaitContainer: true
+  containers:
+    cray-hmnfd:
+      name: "cray-hmnfd"
+      image:
+        repository: "artifactory.algol60.net/csm-docker/stable/cray-hmnfd"
+      ports:
+        - name: http
+          containerPort: 28600
+      env:
+        - name: SM_URL
+          value: "http://cray-smd/hsm/v2"
+        - name: INBOUND_SCN_URL
+          value: "http://cray-hmnfd/hmi/v1/scn"
+        # Remove this to have hmnfd use ETCD.  The etcd operator will
+        # provide the hmnfd container with ETCD_HOST and ETCD_PORT to
+        # allow it to determine the KV URL.
+        # - name: KV_URL
+        #   value: "mem:"
+      livenessProbe:
+        httpGet:
+          port: 28600
+          path: /hmi/v1/liveness
+        initialDelaySeconds: 10
+        periodSeconds: 30
+      readinessProbe:
+        httpGet:
+          port: 28600
+          path: /hmi/v1/readiness
+        initialDelaySeconds: 5
+        periodSeconds: 30
+      resources:
+        limits:
+          cpu: "4"
+          memory: 2Gi
+        requests:
+          cpu: 64m
+          memory: 512Mi
+  podAnnotations:
+    traffic.sidecar.istio.io/excludeOutboundPorts: 8082,9092,2181,2379,2380
+  ingress:
+    enabled: true
+    uri: " "
+    prefix: /apis/hmnfd

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -5,13 +5,15 @@ chartVersionToCSMVersion:
   #   Chart Version: 2.0.0 <= x.y.z < 2.1.0, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   #   Chart Version: 2.1.0 <= x.y.z < 3.0.0, CSM Version: 1.3.0 <= x.y.z < 1.5.0
   #   Chart Version: 3.0.0 <= x.y.z < 4.0.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
-  #   Chart Version: 4.0.0 <= x.y.z,         CSM Version: 1.6.0 <= x.y.z
+  #   Chart Version: 4.0.0 <= x.y.z < 4.1.0, CSM Version: 1.6.0 <= x.y.z < 1.7.0
+  #   Chart Version: 4.1.0 <= x.y.z,         CSM Version: 1.7.0 <= x.y.z
   #
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0"
   ">=2.1.0": "~1.3.0"
   ">=3.0.0": "~1.5.0"
   ">=4.0.0": "~1.6.0"
+  ">=4.1.0": "~1.7.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -38,6 +40,7 @@ chartVersionToApplicationVersion:
   "4.0.4": "1.21.0"
   "4.0.5": "1.22.0"
   "4.0.6": "1.23.0"
+  "4.1.0": "1.24.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Updated version of Go to v1.24.

Fixed pre-existing build warnings in Dockerfiles as it was difficult to look for possible new warnings/errors associated with the image and module updates.

Added image-pprof Makefile support as the above module updates fixed the back-end ARM build issue associated with not being able to enable it previously.

The tavern tests were updated to look for a returned 404 http code rather than a 405 code due to the gorilla/mux change https://github.com/gorilla/mux/pull/712 that came with updating the gorilla module.

Adopted app version 1.24.0 for CSM 1.7.0 (helm chart 4.1.0)

### Issues and Related PRs

* Resolves [CASMHMS-6417](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6417)

### Testing

Ran smoke and integration tests on mug.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

### High Level Chart Changes

```diff
diff -r charts/v4.0/cray-hms-hmnfd/Chart.yaml charts/v4.1/cray-hms-hmnfd/Chart.yaml
3c3
< version: 4.0.6
---
> version: 4.1.0
18c18
< appVersion: "1.23.0"  # update pprof image version below as well
---
> appVersion: "1.24.0"  # update pprof image version below as well
22c22
<       image: artifactory.algol60.net/csm-docker/stable/cray-hmnfd-pprof:1.23.0
---
>       image: artifactory.algol60.net/csm-docker/stable/cray-hmnfd-pprof:1.24.0
diff -r charts/v4.0/cray-hms-hmnfd/values.yaml charts/v4.1/cray-hms-hmnfd/values.yaml
11,12c11,12
<   appVersion: 1.23.0
<   testVersion: 1.23.0
---
>   appVersion: 1.24.0
>   testVersion: 1.24.0
```