### PR TITLE
CASMHMS-6512: Bump cray-etcd-base and cray-service to latest versions

### DIFF
--- a/changelog/v4.1.md
+++ b/changelog/v4.1.md
@@ -5,12 +5,13 @@ All notable changes to this project for v4.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.1.1] - 2025-05-13
+## [4.1.1] - 2025-05-14
 
 ### Updated
 
 - Updated cray-etcd-base and cray-service dependencies to the latest versions
 - Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB
+- Internal tracking ticket: CASMHMS-6512
 
 ## [4.1.0] - 2025-03-25
 

--- a/changelog/v4.1.md
+++ b/changelog/v4.1.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated cray-etcd-base and cray-service dependencies to the latest versions
 - Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB
+- Disabled seccompProfile so chart can deploy on non-1.7 systems
 
 ## [4.1.0] - 2025-03-25
 

--- a/changelog/v4.1.md
+++ b/changelog/v4.1.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated cray-etcd-base and cray-service dependencies to the latest versions
 - Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB
-- Disabled seccompProfile so chart can deploy on non-1.7 systems
 
 ## [4.1.0] - 2025-03-25
 

--- a/changelog/v4.1.md
+++ b/changelog/v4.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v4.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2025-05-13
+
+### Updated
+
+- Updated cray-etcd-base and cray-service dependencies to the latest versions
+- Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB
+
 ## [4.1.0] - 2025-03-25
 
 ### Security

--- a/charts/v4.1/cray-hms-hmnfd/Chart.yaml
+++ b/charts/v4.1/cray-hms-hmnfd/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
 name: "cray-hms-hmnfd"
-version: 4.1.0
+version: 4.1.1
 description: "Kubernetes resources for cray-hms-hmnfd"
 home: "https://github.com/Cray-HPE/hms-hmnfd-charts"
 sources:
   - "https://github.com/Cray-HPE/hms-hmnfd"
 dependencies:
   - name: cray-service
-    version: "~11.0"
+    version: "~12.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-etcd-base
-    version: "~1.2"
+    version: "~1.3"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management

--- a/charts/v4.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v4.1/cray-hms-hmnfd/values.yaml
@@ -41,7 +41,7 @@ cray-etcd-base:
       - name: ETCD_MAX_SNAPSHOTS
         value: "5"
       - name: ETCD_QUOTA_BACKEND_BYTES
-        value: "10737418240"
+        value: "2147483648"
       - name: ETCD_SNAPSHOT_COUNT
         value: "10000"
       - name: ETCD_SNAPSHOT_HISTORY_LIMIT

--- a/charts/v4.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v4.1/cray-hms-hmnfd/values.yaml
@@ -60,6 +60,19 @@ cray-etcd-base:
       requests:
         cpu: 10m
         memory: 64Mi
+    containerSecurityContext:
+      seccompProfile: null
+    disasterRecovery:
+      cronjob:
+        containerSecurityContext:
+          seccompProfile: null
+    preUpgradeJob:
+      containerSecurityContext:
+        seccompProfile: null
+    defrag:
+      cronjob:
+        containerSecurityContext:
+          seccompProfile: null
 
 cray-service:
   type: "Deployment"

--- a/charts/v4.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v4.1/cray-hms-hmnfd/values.yaml
@@ -33,17 +33,6 @@ cray-etcd-base:
         schedule: "0 */1 * * *"
         historyLimit: 1
         snapshotHistoryLimit: 24
-        containerSecurityContext:
-          seccompProfile: null
-    containerSecurityContext:
-      seccompProfile: null
-    preUpgradeJob:
-      containerSecurityContext:
-        seccompProfile: null
-    defrag:
-      cronjob:
-        containerSecurityContext:
-          seccompProfile: null
     extraEnvVars:
       - name: ETCD_HEARTBEAT_INTERVAL
         value: "4200"

--- a/charts/v4.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v4.1/cray-hms-hmnfd/values.yaml
@@ -35,6 +35,15 @@ cray-etcd-base:
         snapshotHistoryLimit: 24
         containerSecurityContext:
           seccompProfile: null
+    containerSecurityContext:
+      seccompProfile: null
+    preUpgradeJob:
+      containerSecurityContext:
+        seccompProfile: null
+    defrag:
+      cronjob:
+        containerSecurityContext:
+          seccompProfile: null
     extraEnvVars:
       - name: ETCD_HEARTBEAT_INTERVAL
         value: "4200"
@@ -62,15 +71,6 @@ cray-etcd-base:
       requests:
         cpu: 10m
         memory: 64Mi
-    containerSecurityContext:
-      seccompProfile: null
-    preUpgradeJob:
-      containerSecurityContext:
-        seccompProfile: null
-    defrag:
-      cronjob:
-        containerSecurityContext:
-          seccompProfile: null
 
 cray-service:
   type: "Deployment"

--- a/charts/v4.1/cray-hms-hmnfd/values.yaml
+++ b/charts/v4.1/cray-hms-hmnfd/values.yaml
@@ -33,6 +33,8 @@ cray-etcd-base:
         schedule: "0 */1 * * *"
         historyLimit: 1
         snapshotHistoryLimit: 24
+        containerSecurityContext:
+          seccompProfile: null
     extraEnvVars:
       - name: ETCD_HEARTBEAT_INTERVAL
         value: "4200"
@@ -62,10 +64,6 @@ cray-etcd-base:
         memory: 64Mi
     containerSecurityContext:
       seccompProfile: null
-    disasterRecovery:
-      cronjob:
-        containerSecurityContext:
-          seccompProfile: null
     preUpgradeJob:
       containerSecurityContext:
         seccompProfile: null

--- a/cray-hms-hmnfd.compatibility.yaml
+++ b/cray-hms-hmnfd.compatibility.yaml
@@ -41,6 +41,7 @@ chartVersionToApplicationVersion:
   "4.0.5": "1.22.0"
   "4.0.6": "1.23.0"
   "4.1.0": "1.24.0"
+  "4.1.1": "1.24.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated cray-etcd-base and cray-service dependencies to the latest versions

Decreased ETCD_QUOTA_BACKEND_BYTES from 10 GB to 2 GB

New helm chart version is 4.1.1 (no app version change)

### Issues and Related PRs

* Resolves [CASMHMS-6512](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6512)

### Testing

Tested on:

* `beau` (vshasta)

Test description:

- Helm upgrade of the new chart
  - Had to do a 'rollout restart' to restart the pods since the container image didn't change
- Ran HMS CT tests
- Ran etcd health checks to ensure things were healthy from the start:
  - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_health_status`
  - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_database_health`
    - One pod had a websocket issue which was later cleared up by the etcd rebuild
- Rebuilt the etcd cluster with:
   - `/opt/cray/platform-utils/etcd/etcd_restore_rebuild.sh -s cray-hmnfd`
 - Reran etcd health checks to ensure things were still healthy after the rebuild:
   - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_health_status`
   - `/opt/cray/platform-utils/ncnHealthChecks.sh -s etcd_database_health`
- There were no HMNFD subscriptions to resubscribe
- Re-ran HMS CT tests to verify all tests still pass after the rebuild
- Helm rollback to the prior version of the service

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable